### PR TITLE
Switch from rustc_serialize to serde and fix RepoTags null problem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ ssl = ["openssl", "hyper/ssl"]
 error-chain = "0.5.0"
 hyper = { version = "0.9", default-features = false }
 openssl = { version = "0.7", optional = true }
-rustc-serialize = "0.3.16"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
 url = "1.2.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,9 +1,8 @@
-use rustc_serialize::json;
 use std;
 use std::error::Error;
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 //Labels, HostConfig
 pub struct Container {
@@ -20,7 +19,7 @@ pub struct Container {
     pub HostConfig: HostConfig
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Port {
     pub IP: Option<String>,
@@ -29,13 +28,13 @@ pub struct Port {
     pub Type: String
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct HostConfig {
     pub NetworkMode: String
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct ContainerInfo {
     pub AppArmorProfile: String,
@@ -65,7 +64,7 @@ pub struct ContainerInfo {
 /// This type represents a `struct{}` in the Go code.
 pub type UnspecifiedObject = HashMap<String, String>;
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Config {
     pub AttachStderr: bool,
@@ -92,7 +91,7 @@ pub struct Config {
     pub WorkingDir: String,
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Mount {
     // Name (optional)
@@ -104,7 +103,7 @@ pub struct Mount {
     pub Propagation: String,
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct NetworkSettings {
     pub Bridge: String,
@@ -128,7 +127,7 @@ pub struct NetworkSettings {
     //pub SecondaryIPv6Addresses: ,
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Network {
     pub Aliases: Option<Vec<String>>,
@@ -145,14 +144,14 @@ pub struct Network {
     pub NetworkID: String,
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct PortMapping {
     pub HostIp: String,
     pub HostPort: String,
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct State {
     pub Status: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 //! Error-handling with the `error_chain` crate.
 
 use hyper;
-use rustc_serialize::json;
 use std::env;
 use std::io;
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct FilesystemChange {
     pub Path: String,

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Image {
     pub Created: u64,
@@ -9,7 +9,7 @@ pub struct Image {
     pub VirtualSize: u64
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageStatus {
     pub status: Option<String>,
     pub error: Option<String>

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,9 +1,21 @@
+use serde::de::{Deserializer, DeserializeOwned};
+use serde::Deserialize;
+
+fn null_to_default<'de, D, T>(de: D) -> Result<T, D::Error>
+    where D: Deserializer<'de>,
+          T: DeserializeOwned + Default
+{
+    let actual : Option<T> = Option::deserialize(de)?;
+    Ok(actual.unwrap_or_default())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Image {
     pub Created: u64,
     pub Id: String,
     pub ParentId: String,
+    #[serde(deserialize_with = "null_to_default")]
     pub RepoTags: Vec<String>,
     pub Size: u64,
     pub VirtualSize: u64

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,10 @@ extern crate openssl;
 extern crate named_pipe;
 #[cfg(unix)]
 extern crate unix_socket;
-extern crate rustc_serialize;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate serde;
 extern crate url;
 
 // declare modules

--- a/src/process.rs
+++ b/src/process.rs
@@ -16,7 +16,7 @@ pub struct Process {
     pub command: String,
 }
 
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Top {
     pub Titles: Vec<String>,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,7 +5,7 @@ use std::iter;
 use std::io::{BufRead, BufReader};
 use hyper::client::response::Response;
 
-use rustc_serialize::json;
+use serde_json;
 
 use errors::*;
 
@@ -29,12 +29,12 @@ impl iter::Iterator for StatsReader {
         if let Err(err) = self.buf.read_line(&mut line) {
             return Some(Err(err.into()));
         }
-        Some(json::decode::<Stats>(&line)
+        Some(serde_json::from_str::<Stats>(&line)
             .chain_err(|| ErrorKind::ParseError("Stats", line)))
     }
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stats {
     pub read: String,
     pub network: Network,
@@ -43,7 +43,7 @@ pub struct Stats {
     pub blkio_stats: BlkioStats
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Network {
     pub rx_dropped: u64,
     pub rx_bytes: u64,
@@ -55,7 +55,7 @@ pub struct Network {
     pub tx_bytes: u64
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryStats {
     pub max_usage: u64,
     pub usage: u64,
@@ -64,7 +64,7 @@ pub struct MemoryStats {
     pub stats: MemoryStat
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryStat {
     pub total_pgmajfault: u64,
     pub cache: u64,
@@ -100,14 +100,14 @@ pub struct MemoryStat {
     pub total_swap: u64
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CpuStats {
     pub cpu_usage: CpuUsage,
     pub system_cpu_usage: u64,
     pub throttling_data: ThrottlingData
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CpuUsage {
     pub percpu_usage: Vec<u64>,
     pub usage_in_usermode: u64,
@@ -115,14 +115,14 @@ pub struct CpuUsage {
     pub usage_in_kernelmode: u64
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThrottlingData {
     pub periods: u64,
     pub throttled_periods: u64,
     pub throttled_time: u64
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlkioStats {
     pub io_service_bytes_recursive: Vec<BlkioStat>,
     pub io_serviced_recursive: Vec<BlkioStat>,
@@ -134,7 +134,7 @@ pub struct BlkioStats {
     pub sectors_recursive: Vec<BlkioStat>
 }
 
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlkioStat {
     pub major: u64,
     pub minor: u64,

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct SystemInfo {
     pub Containers: u64,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use rustc_serialize::json;
+use serde_json;
 #[cfg(test)]
 use container::{Container, ContainerInfo};
 #[cfg(test)]
@@ -29,7 +29,7 @@ use std::io::Write;
 #[cfg(test)]
 fn get_containers() {
     let response = get_containers_response();
-    let _: Vec<Container> = match json::decode(&response) {
+    let _: Vec<Container> = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };
@@ -41,7 +41,7 @@ fn get_stats_single() {
     let response = get_stats_single_event(1);
 
     print!("{}", response);
-    let _: Stats = match json::decode(&response) {
+    let _: Stats = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };
@@ -72,7 +72,7 @@ fn get_stats_streaming() {
 #[cfg(test)]
 fn get_system_info() {
     let response = get_system_info_response();
-    let _: SystemInfo = match json::decode(&response) {
+    let _: SystemInfo = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };
@@ -82,7 +82,7 @@ fn get_system_info() {
 #[cfg(test)]
 fn get_images() {
     let response = get_images_response();
-    let _: Vec<Image> = match json::decode(&response) {
+    let _: Vec<Image> = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };
@@ -92,14 +92,14 @@ fn get_images() {
 #[cfg(test)]
 fn get_container_info() {
     let response = get_container_info_response();
-    json::decode::<ContainerInfo>(&response).unwrap();
+    serde_json::from_str::<ContainerInfo>(&response).unwrap();
 }
 
 #[test]
 #[cfg(test)]
 fn get_processes() {
     let response = get_processes_response();
-    let _: Top = match json::decode(&response) {
+    let _: Top = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };
@@ -109,7 +109,7 @@ fn get_processes() {
 #[cfg(test)]
 fn get_filesystem_changes() {
     let response = get_filesystem_changes_response();
-    let _: Vec<FilesystemChange> = match json::decode(&response) {
+    let _: Vec<FilesystemChange> = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };
@@ -119,7 +119,7 @@ fn get_filesystem_changes() {
 #[cfg(test)]
 fn get_version(){
     let response = get_version_response();
-    let _: Version = match json::decode(&response) {
+    let _: Version = match serde_json::from_str(&response) {
         Ok(body) => body,
         Err(_) => { assert!(false); return; }
     };

--- a/src/test.rs
+++ b/src/test.rs
@@ -82,10 +82,8 @@ fn get_system_info() {
 #[cfg(test)]
 fn get_images() {
     let response = get_images_response();
-    let _: Vec<Image> = match serde_json::from_str(&response) {
-        Ok(body) => body,
-        Err(_) => { assert!(false); return; }
-    };
+    let images : Vec<Image> = serde_json::from_str(&response).unwrap();
+    assert_eq!(3, images.len());
 }
 
 #[test]
@@ -142,7 +140,8 @@ fn get_system_info_response() -> String {
 
 #[cfg(test)]
 fn get_images_response() -> String {
-    return "[{\"Created\":1428533761,\"Id\":\"533da4fa223bfbca0f56f65724bb7a4aae7a1acd6afa2309f370463eaf9c34a4\",\"ParentId\":\"84ac0b87e42afe881d36f03dea817f46893f9443f9fc10b64ec279737384df12\",\"RepoTags\":[\"ghmlee/rust:nightly\"],\"Size\":0,\"VirtualSize\":806688288},{\"Created\":1371157430,\"Id\":\"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158\",\"ParentId\":\"\",\"RepoTags\":[],\"Size\":0,\"VirtualSize\":0}]".to_string();
+    return "[{\"Created\":1428533761,\"Id\":\"533da4fa223bfbca0f56f65724bb7a4aae7a1acd6afa2309f370463eaf9c34a4\",\"ParentId\":\"84ac0b87e42afe881d36f03dea817f46893f9443f9fc10b64ec279737384df12\",\"RepoTags\":[\"ghmlee/rust:nightly\"],\"Size\":0,\"VirtualSize\":806688288},{\"Created\":1371157430,\"Id\":\"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158\",\"ParentId\":\"\",\"RepoTags\":[],\"Size\":0,\"VirtualSize\":0},
+    {\"Created\":1371157430,\"Id\":\"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158\",\"ParentId\":\"\",\"RepoTags\":null,\"Size\":0,\"VirtualSize\":0}]".to_string();
 }
 
 #[cfg(test)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct Version {
    pub Version: String,


### PR DESCRIPTION
I don't know if you want this but I have updated boondock to use serde_json instead of rustc_serialize.

While doing that I also found a small problem in that RepoTags field of Image can be null so I have made a custom deserializer that handles null by setting RepoTags to an empty Vec.