### PR TITLE
Add client timeout

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,6 +1,6 @@
 use std;
 use std::collections::BTreeMap;
-use std::env;
+use std::{env, time};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::io::{self, Read};
@@ -363,5 +363,9 @@ impl Docker {
 
     pub fn version(&self) -> Result<Version> {
         self.decode_url("Version", "/version")
+    }
+
+    pub fn set_read_timeout(&mut self, dur: Option<time::Duration>) {
+        self.client.set_read_timeout(dur)
     }
 }


### PR DESCRIPTION
Adds a configurable timeout for the docker client. Before, I believe it was indefinite according to https://hyper.rs/hyper/0.8.0/src/hyper/src/client/mod.rs.html#129