### PR TITLE
Error handling for non-successful Docker responses

### DIFF
--- a/src/docker.rs
+++ b/src/docker.rs
@@ -205,7 +205,10 @@ impl Docker {
 
     fn execute_request(&self, request: RequestBuilder) -> Result<String> {
         let mut response = try!(request.send());
-        assert!(response.status.is_success());
+
+        if !response.status.is_success() {
+            return Ok(Err(ErrorKind::DockerNoSuccessError(response.status.to_u16()))?)
+        }
 
         let mut body = String::new();
         try!(response.read_to_string(&mut body));
@@ -214,7 +217,11 @@ impl Docker {
 
     fn start_request(&self, request: RequestBuilder) -> Result<Response> {
         let response = try!(request.send());
-        assert!(response.status.is_success());
+
+        if !response.status.is_success() {
+            return Ok(Err(ErrorKind::DockerNoSuccessError(response.status.to_u16()))?)
+        }
+
         Ok(response)
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -46,5 +46,10 @@ error_chain! {
             description("unsupported Docker URL scheme")
             display("do not know how to connect to Docker at '{}'", &host)
         }
+
+        DockerNoSuccessError(status_code: u16) {
+            description("Docker server failed to respond with a successful message")
+            display("Docker responded with status code {}", status_code )
+        }
     }
 }


### PR DESCRIPTION
Adds error-handling around a non-success response from the Docker daemon, so that thread does not panic.