### PR TITLE
Image load api

### DIFF
--- a/examples/load.rs
+++ b/examples/load.rs
@@ -1,0 +1,11 @@
+extern crate boondock;
+
+use std::path::Path;
+use boondock::Docker;
+
+fn main() {
+    let docker = Docker::connect_with_defaults().unwrap();
+    docker
+        .load_image(false, Path::new("image.tar"))
+        .expect("prepare a tar-archive like: $docker save busybox > image.tar");
+}

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -189,7 +189,7 @@ impl Docker {
             ClientType::Unix => {
                 // We need a host so the HTTP headers can be generated, so we just spoof it and say
                 // that we're talking to localhost.  The hostname doesn't matter one bit.
-                "http://localhost/".to_string()
+                "http://localhost".to_string()
             }
         };
         let new_path = path.clone();


### PR DESCRIPTION
Imiplement loading image api wrapper (`Docker::load_image`).
This method enable users to loading image tar-archive which is extracted with `docker save` command.
